### PR TITLE
split by tabs when loading model

### DIFF
--- a/applytc.py
+++ b/applytc.py
@@ -19,7 +19,7 @@ def loadModel(filename, freqs = False):
 	
 	with open(filename, 'r') as filehandle:
 		for w in filehandle:
-			w, f = w.strip().split()
+			w, f = w.strip().split('\t')
 			
 			res[w.lower()] = WordFreqTuple(w, int(f))
 		


### PR DESCRIPTION
When the model is trained on untokenized text, lines like "21. August	103" can appear in the model file, and `applytc.loadModel` throws a `ValueError`, because it expects 2 elements. I replaced `.split()` with `.split('\t')` so that it doesn't happen.