### PR TITLE
Fix learntc import

### DIFF
--- a/applytc.py
+++ b/applytc.py
@@ -4,7 +4,7 @@ import sys
 import re
 import regex
 
-from truecaser.learntc import log, tokens
+from learntc import log, tokens
 
 class DefUniqDict(dict):
 	def __missing__(self, key):


### PR DESCRIPTION
In `applytc.py`, replaced `from truecaser.learntc import log, tokens` with `from learntc import log, tokens`.

When I clone the code to my local machine or Colab and try to apply a learned model, I get an error:

```
Traceback (most recent call last):
  File "applytc.py", line 7, in <module>
    from truecaser.learntc import log, tokens
ModuleNotFoundError: No module named 'truecaser'
```

As `learntc.py` and `applytc.py` are in the same location, my change fixes this problem.